### PR TITLE
bugfix: fix exceptions handler decoding from bytes

### DIFF
--- a/gpt2giga/utils.py
+++ b/gpt2giga/utils.py
@@ -23,6 +23,8 @@ def exceptions_handler(func):
                     error_detail = json.loads(message)
                 except Exception:
                     error_detail = message
+                    if isinstance(error_detail, bytes):
+                        error_detail = error_detail.decode("utf-8", errors="ignore")
                 raise HTTPException(
                     status_code=status_code,
                     detail={


### PR DESCRIPTION
Fix ```TypeError: Object of type bytes is not JSON serializable``` error. If the server returns an error with an empty body (just bytes b''), the program tries to save this error in JSON to show it, but "forgets" to turn the bytes into a string, which causes the program to crash.