### PR TITLE
bugfix: fix exceptions handler decoding from bytes (#47)

### DIFF
--- a/gpt2giga/utils.py
+++ b/gpt2giga/utils.py
@@ -23,6 +23,8 @@ def exceptions_handler(func):
                     error_detail = json.loads(message)
                 except Exception:
                     error_detail = message
+                    if isinstance(error_detail, bytes):
+                        error_detail = error_detail.decode("utf-8", errors="ignore")
                 raise HTTPException(
                     status_code=status_code,
                     detail={


### PR DESCRIPTION
This pull request introduces a small improvement to error handling in the `gpt2giga/utils.py` utility module. The change ensures that error details are always decoded into a string, even if they are received as bytes.

* Error Handling Improvement:
  * In the `wrapper` function, added logic to decode `error_detail` from bytes to a UTF-8 string if necessary, preventing potential issues with non-string error messages.