### PR TITLE
bugfix: create a new gigachat instance if pass_token=True

### DIFF
--- a/gpt2giga/api_server.py
+++ b/gpt2giga/api_server.py
@@ -39,9 +39,7 @@ async def lifespan(app: FastAPI):
     app.state.logger = logger
     app.state.gigachat_client = GigaChat(**config.gigachat_settings.model_dump())
 
-    attachment_processor = AttachmentProcessor(
-        app.state.gigachat_client, app.state.logger
-    )
+    attachment_processor = AttachmentProcessor(app.state.logger)
     app.state.request_transformer = RequestTransformer(
         config, app.state.logger, attachment_processor
     )

--- a/gpt2giga/protocol/attachments.py
+++ b/gpt2giga/protocol/attachments.py
@@ -11,13 +11,12 @@ from gigachat import GigaChat
 class AttachmentProcessor:
     """Обработчик изображений с кэшированием"""
 
-    def __init__(self, giga_client: GigaChat, logger):
-        self.giga = giga_client
+    def __init__(self, logger):
         self.logger = logger
         self.cache: dict[str, str] = {}
 
     async def upload_file(
-        self, image_url: str, filename: str | None = None
+        self, giga_client: GigaChat, image_url: str, filename: str | None = None
     ) -> Optional[str]:
         """Загружает файл в GigaChat и возвращает file_id"""
 
@@ -44,7 +43,7 @@ class AttachmentProcessor:
             ext = content_type.split("/")[-1] or "jpg"
             filename = filename or f"{uuid.uuid4()}.{ext}"
             self.logger.info(f"Uploading file to GigaChat... with extension {ext}")
-            file = await self.giga.aupload_file((filename, content_bytes))
+            file = await giga_client.aupload_file((filename, content_bytes))
 
             self.cache[hashed] = file.id_
             self.logger.info(f"File uploaded successfully, file_id: {file.id_}")

--- a/gpt2giga/routers/api_router.py
+++ b/gpt2giga/routers/api_router.py
@@ -21,7 +21,8 @@ router = APIRouter(tags=["API"])
 @exceptions_handler
 async def show_available_models(request: Request):
     state = request.app.state
-    response = await state.gigachat_client.aget_models()
+    giga_client = getattr(request.state, "gigachat_client", state.gigachat_client)
+    response = await giga_client.aget_models()
     models = [i.model_dump(by_alias=True) for i in response.data]
     current_timestamp = int(time.time())
     for model in models:
@@ -35,7 +36,8 @@ async def show_available_models(request: Request):
 @exceptions_handler
 async def get_model(model: str, request: Request):
     state = request.app.state
-    response = await state.gigachat_client.aget_model(model=model)
+    giga_client = getattr(request.state, "gigachat_client", state.gigachat_client)
+    response = await giga_client.aget_model(model=model)
     model = response.model_dump(by_alias=True)
     model["created"] = int(time.time())
     return OpenAIModel(**model)
@@ -49,12 +51,15 @@ async def chat_completions(request: Request):
     tools = "tools" in data or "functions" in data
     current_rquid = rquid_context.get()
     state = request.app.state
+    giga_client = getattr(request.state, "gigachat_client", state.gigachat_client)
     if tools:
         data["functions"] = convert_tool_to_giga_functions(data)
         state.logger.debug(f"Functions count: {len(data['functions'])}")
-    chat_messages = await state.request_transformer.prepare_chat_completion(data)
+    chat_messages = await state.request_transformer.prepare_chat_completion(
+        data, giga_client
+    )
     if not stream:
-        response = await state.gigachat_client.achat(chat_messages)
+        response = await giga_client.achat(chat_messages)
         processed = state.response_processor.process_response(
             response, data["model"], current_rquid, request_data=data
         )
@@ -62,7 +67,7 @@ async def chat_completions(request: Request):
     else:
         return StreamingResponse(
             stream_chat_completion_generator(
-                request, data["model"], chat_messages, current_rquid
+                request, data["model"], chat_messages, current_rquid, giga_client
             ),
             media_type="text/event-stream",
         )
@@ -92,7 +97,10 @@ async def embeddings(request: Request):
     else:
         new_inputs = [inputs]
 
-    embeddings = await request.app.state.gigachat_client.aembeddings(
+    giga_client = getattr(
+        request.state, "gigachat_client", request.app.state.gigachat_client
+    )
+    embeddings = await giga_client.aembeddings(
         texts=new_inputs, model=request.app.state.config.proxy_settings.embeddings
     )
 
@@ -107,18 +115,21 @@ async def responses(request: Request):
     tools = "tools" in data or "functions" in data
     current_rquid = rquid_context.get()
     state = request.app.state
+    giga_client = getattr(request.state, "gigachat_client", state.gigachat_client)
     if tools:
         data["functions"] = convert_tool_to_giga_functions(data)
         state.logger.debug(f"Functions count: {len(data['functions'])}")
-    chat_messages = await state.request_transformer.prepare_response(data)
+    chat_messages = await state.request_transformer.prepare_response(data, giga_client)
     if not stream:
-        response = await state.gigachat_client.achat(chat_messages)
+        response = await giga_client.achat(chat_messages)
         processed = state.response_processor.process_response_api(
             data, response, data["model"], current_rquid
         )
         return processed
     else:
         return StreamingResponse(
-            stream_responses_generator(request, chat_messages, current_rquid),
+            stream_responses_generator(
+                request, chat_messages, current_rquid, giga_client
+            ),
             media_type="text/event-stream",
         )


### PR DESCRIPTION
This pull request refactors how the `GigaChat` client is managed and passed throughout the codebase, making client usage more explicit and flexible, especially in scenarios where per-request authentication tokens are used. It also updates attachment and message processing to accept the client as a parameter, and ensures all API endpoints and streaming utilities use the correct instance of `GigaChat`.

**Refactoring GigaChat client management:**

- The `AttachmentProcessor` no longer stores a `GigaChat` client instance. Instead, the client is now passed as an argument to methods that require it, such as `upload_file` (`gpt2giga/protocol/attachments.py`) [[1]](diffhunk://#diff-648daf566a210051f5ae183ba845660e4bd3ade6d40098b7f92642ba06b1db7eL14-R19) [[2]](diffhunk://#diff-648daf566a210051f5ae183ba845660e4bd3ade6d40098b7f92642ba06b1db7eL47-R46).
- The `RequestTransformer` and related message transformation methods (`transform_messages`, `prepare_chat_completion`, etc.) now accept an optional `giga_client` parameter, ensuring that the correct client (possibly with a per-request token) is used throughout the request lifecycle (`gpt2giga/protocol/request_mapper.py`) [[1]](diffhunk://#diff-98f33f70e3a58b32fc1b139720995ddbfff429ed4df5eed36538133c397514adL27-R30) [[2]](diffhunk://#diff-98f33f70e3a58b32fc1b139720995ddbfff429ed4df5eed36538133c397514adL66-R69) [[3]](diffhunk://#diff-98f33f70e3a58b32fc1b139720995ddbfff429ed4df5eed36538133c397514adL81-R84) [[4]](diffhunk://#diff-98f33f70e3a58b32fc1b139720995ddbfff429ed4df5eed36538133c397514adL107-R133) [[5]](diffhunk://#diff-98f33f70e3a58b32fc1b139720995ddbfff429ed4df5eed36538133c397514adL308-R329) [[6]](diffhunk://#diff-98f33f70e3a58b32fc1b139720995ddbfff429ed4df5eed36538133c397514adL328-R378).

**Middleware and per-request client handling:**

- The middleware now sets `request.state.gigachat_client` for each request, allowing endpoints and utilities to use a client instance that may include a user-specific token (`gpt2giga/middlewares/pass_token.py`).
- When a token is passed, a new `GigaChat` client is created for the request, and this instance is used instead of the global one (`gpt2giga/middlewares/pass_token.py`).

**API endpoints updated for explicit client usage:**

- All API endpoints now retrieve the `GigaChat` client from `request.state.gigachat_client` if available, falling back to the application-level client otherwise. This ensures the correct client (with the appropriate token) is used for each request (`gpt2giga/routers/api_router.py`) [[1]](diffhunk://#diff-4424ddd1e29cf88cfb50de8d667668c375d25e47a113d4207a3633962b75c72aL24-R25) [[2]](diffhunk://#diff-4424ddd1e29cf88cfb50de8d667668c375d25e47a113d4207a3633962b75c72aL38-R40) [[3]](diffhunk://#diff-4424ddd1e29cf88cfb50de8d667668c375d25e47a113d4207a3633962b75c72aR54-R70) [[4]](diffhunk://#diff-4424ddd1e29cf88cfb50de8d667668c375d25e47a113d4207a3633962b75c72aL95-R103) [[5]](diffhunk://#diff-4424ddd1e29cf88cfb50de8d667668c375d25e47a113d4207a3633962b75c72aR118-R133).

**Streaming utilities updated:**

- The streaming response generators (`stream_chat_completion_generator` and `stream_responses_generator`) now accept an optional `giga_client` parameter and use it for streaming, defaulting to the app-level client if not provided (`gpt2giga/utils.py`) [[1]](diffhunk://#diff-51853a19e59ca250246fbe944cdc20f8a8fc152b9ce89623ac3eb172c748ef15L110-R119) [[2]](diffhunk://#diff-51853a19e59ca250246fbe944cdc20f8a8fc152b9ce89623ac3eb172c748ef15L129-R143).

**Other minor improvements:**

- Imports and type annotations updated to reflect the new usage of `GigaChat` and optional parameters (`gpt2giga/middlewares/pass_token.py`, `gpt2giga/protocol/request_mapper.py`, `gpt2giga/utils.py`) [[1]](diffhunk://#diff-28e58610b404097905331caf538352d32b57a81e03715c754bd2370422fcaf6cR4) [[2]](diffhunk://#diff-98f33f70e3a58b32fc1b139720995ddbfff429ed4df5eed36538133c397514adR4) [[3]](diffhunk://#diff-51853a19e59ca250246fbe944cdc20f8a8fc152b9ce89623ac3eb172c748ef15L3-R3).

This refactor improves flexibility, testability, and security by making the GigaChat client usage explicit and per-request, especially important for token-passing scenarios.