### PR TITLE
fix: учитывать encoding_format=base64 на /v1/embeddings

### DIFF
--- a/gpt2giga/routers/openai/embeddings.py
+++ b/gpt2giga/routers/openai/embeddings.py
@@ -1,5 +1,9 @@
 """OpenAI embeddings endpoint."""
 
+import base64
+import struct
+from typing import Any
+
 from fastapi import APIRouter, Request
 
 from gpt2giga.app_state import get_gigachat_client
@@ -11,6 +15,35 @@ from gpt2giga.protocol.batches import transform_embedding_body
 router = APIRouter(tags=["OpenAI"])
 
 
+def _apply_encoding_format(response: Any, encoding_format: Any) -> Any:
+    """Pack each embedding as base64 of little-endian float32 bytes when asked.
+
+    GigaChat always returns float arrays, while OpenAI's Python and Node
+    SDKs default to ``encoding_format='base64'`` on ``embeddings.create`` and
+    decode the string back to floats client-side. Without honoring the
+    field, the proxy silently breaks those clients.
+    """
+    if encoding_format != "base64":
+        return response
+    if hasattr(response, "model_dump"):
+        response = response.model_dump()
+    elif hasattr(response, "dict"):
+        response = response.dict()
+    if not isinstance(response, dict):
+        return response
+    items = response.get("data")
+    if not isinstance(items, list):
+        return response
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        embedding = item.get("embedding")
+        if isinstance(embedding, list) and embedding:
+            packed = struct.pack(f"<{len(embedding)}f", *embedding)
+            item["embedding"] = base64.b64encode(packed).decode("ascii")
+    return response
+
+
 @router.post("/embeddings", openapi_extra=embeddings_openapi_extra())
 @exceptions_handler
 async def embeddings(request: Request):
@@ -20,6 +53,7 @@ async def embeddings(request: Request):
     transformed = await transform_embedding_body(
         data, request.app.state.config.proxy_settings.embeddings
     )
-    return await giga_client.aembeddings(
+    response = await giga_client.aembeddings(
         texts=transformed["input"], model=transformed["model"]
     )
+    return _apply_encoding_format(response, data.get("encoding_format"))

--- a/tests/test_embeddings_encoding_format.py
+++ b/tests/test_embeddings_encoding_format.py
@@ -1,0 +1,80 @@
+"""Tests for OpenAI ``encoding_format`` handling on /v1/embeddings."""
+
+import base64
+import struct
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from gpt2giga.models.config import ProxyConfig
+from gpt2giga.routers.openai import router as openai_router
+
+
+class FakeClient:
+    """Stand-in GigaChat client that always returns float arrays."""
+
+    async def aembeddings(self, texts, model):
+        return {
+            "data": [
+                {
+                    "embedding": [0.0, 0.5, -0.5, 1.0],
+                    "index": 0,
+                    "object": "embedding",
+                }
+            ],
+            "model": model,
+            "object": "list",
+        }
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(openai_router)
+    app.state.gigachat_client = FakeClient()
+    app.state.config = ProxyConfig()
+    return app
+
+
+def test_embeddings_default_encoding_returns_floats():
+    """Without ``encoding_format`` the response keeps float arrays."""
+    client = TestClient(_make_app())
+    resp = client.post("/embeddings", json={"input": "hello"})
+    assert resp.status_code == 200
+    embedding = resp.json()["data"][0]["embedding"]
+    assert isinstance(embedding, list)
+    assert embedding == [0.0, 0.5, -0.5, 1.0]
+
+
+def test_embeddings_explicit_float_returns_floats():
+    """Explicit ``encoding_format='float'`` keeps float arrays."""
+    client = TestClient(_make_app())
+    resp = client.post(
+        "/embeddings",
+        json={"input": "hello", "encoding_format": "float"},
+    )
+    assert resp.status_code == 200
+    embedding = resp.json()["data"][0]["embedding"]
+    assert isinstance(embedding, list)
+    assert embedding == [0.0, 0.5, -0.5, 1.0]
+
+
+def test_embeddings_base64_returns_base64_string():
+    """``encoding_format='base64'`` packs floats as little-endian float32 bytes
+    and base64-encodes them, matching the OpenAI API contract.
+
+    The OpenAI Python and Node SDKs default to ``encoding_format='base64'``
+    on ``embeddings.create`` and decode the string back to floats client-side.
+    Without honoring the field, callers silently receive corrupt data.
+    """
+    client = TestClient(_make_app())
+    resp = client.post(
+        "/embeddings",
+        json={"input": "hello", "encoding_format": "base64"},
+    )
+    assert resp.status_code == 200
+    embedding = resp.json()["data"][0]["embedding"]
+    assert isinstance(embedding, str)
+    raw = base64.b64decode(embedding)
+    assert len(raw) == 4 * 4  # 4 floats × 4 bytes (float32)
+    decoded = list(struct.unpack(f"<{len(raw) // 4}f", raw))
+    assert decoded == [0.0, 0.5, -0.5, 1.0]


### PR DESCRIPTION
## Описание

`/v1/embeddings` объявляет параметр `encoding_format` в OpenAPI-extras (enum `["float", "base64"]`, помечен «OpenAI compatibility parameter (best effort)»), но хендлер его игнорирует: GigaChat возвращает массивы `float`, и прокси отдаёт их как есть, даже если клиент явно попросил `base64`.

Это молча ломает OpenAI Python и Node SDK — оба по умолчанию шлют `encoding_format='base64'` в `embeddings.create` и декодируют поле `embedding` как base64-строку с упакованным little-endian `float32`-буфером. Когда вместо строки в `embedding` приходит JSON-массив, декодер SDK выдаёт мусор без ошибки.

## Мотивация

Привести поведение к документированному контракту OpenAI, чтобы немодифицированные OpenAI SDK (которые по умолчанию ожидают `base64`) корректно работали через gpt2giga. Сейчас любой Node-SDK-клиент `/v1/embeddings` молча получает повреждённые векторы, если не указывает явно `encoding_format: 'float'`.

Референс OpenAI: <https://platform.openai.com/docs/api-reference/embeddings/create#embeddings-create-encoding_format>

## Тип изменений

- [x] Bug fix (non-breaking change that fixes an issue)

## Что изменено

- `gpt2giga/routers/openai/embeddings.py`: читаем `encoding_format` из тела запроса; если значение `base64`, упаковываем каждый `data[*].embedding` как little-endian `float32` и кодируем в base64 перед отдачей. Поведение по умолчанию (`float` либо отсутствие поля) не меняется.
- `tests/test_embeddings_encoding_format.py`: три новых теста — путь по умолчанию, явный `float`, `base64` с round-trip `base64 → bytes → float32 → list`.

## Тестирование

```
uv run pytest tests/ --cov=. --cov-report=term --cov-fail-under=80
# 274 passed (+3 новых), coverage 87.49% (gate 80% выполнен)

uv run ruff check .
# All checks passed!
```

### Ручная проверка — воспроизведение бага (до изменений)

```bash
curl -sS http://127.0.0.1:8090/v1/embeddings \
  -H 'Authorization: Bearer $KEY' -H 'Content-Type: application/json' \
  -d '{"model":"Embeddings-2","input":"hi","encoding_format":"base64"}' \
  | jq '.data[0].embedding | type, length'
# "array"
# 1024
```

При дефолтном вызове OpenAI Node SDK (`encoding_format='base64'`) клиент молча декодирует «массив-как-строку» в мусорный 256-элементный вектор вместо реального 1024-мерного эмбеддинга.

### После изменений

```bash
curl -sS http://127.0.0.1:8090/v1/embeddings \
  -H 'Authorization: Bearer $KEY' -H 'Content-Type: application/json' \
  -d '{"model":"Embeddings-2","input":"hi","encoding_format":"base64"}' \
  | jq '.data[0].embedding | type'
# "string"
```

## Чеклист

- [x] Код соответствует стилю проекта; `uv run ruff check .` — All checks passed
- [x] Все тесты проходят (`uv run pytest`)
- [x] Docstrings — Google-style, повелительное наклонение
- [x] Новых зависимостей не добавлено (используются stdlib `base64` и `struct`)
- [x] Совместимо с Python 3.10–3.14
- [x] Сообщения коммитов следуют conventional commits

## Дополнительный контекст

- Поведение по умолчанию не меняется (`encoding_format` отсутствует или равен `float` — отдаём существующий JSON-массив).
- Helper устойчив и к `dict`, и к Pydantic-модели (`model_dump` / `dict` fallback), что страхует от возможных изменений формы ответа в GigaChat SDK.
- OpenAPI-extras уже объявляли это поле — патч приводит реализацию в соответствие с опубликованной спецификацией, снимая оговорку «best effort» для пути `base64`.

### Примечание по CI

Job `Generate coverage badge` падает на step «Checkout repository»: workflow жёстко чекаутит `repository: ai-forever/gpt2giga` + `ref: fix/embeddings-encoding-format-base64`, а ветка этого PR находится в форке (`vzd3v/gpt2giga`) — поэтому fetch не находит ref. Все остальные проверки (pytest на Python 3.10–3.14, CodeQL, dependency-review) зелёные. Это конфиг-особенность workflow для PR из внешних форков, а не следствие изменений PR.
