### PR TITLE
feat: LAR-1 семантическая маршрутизация для chat completions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -170,3 +170,20 @@ GIGACHAT_TIMEOUT=70000
 #MITMPROXY_PASSWORD=12345
 #MITMPROXY_PORT=8080
 #MITMPROXY_WEB_PORT=8081
+
+# ── LAR-1 Semantic Routing ──────────────────────────────
+# Enable LAR-1 metadata processing (off by default)
+LAR1_ENABLED=false
+
+# Confidence thresholds (0.0-1.0, must satisfy low < medium < high)
+LAR1_THRESHOLD_LOW=0.3
+LAR1_THRESHOLD_MEDIUM=0.5
+LAR1_THRESHOLD_HIGH=0.7
+
+# Map LAR-1 routes to upstream GigaChat model ids
+# gigachat-fast — экономичная: low-confidence или UNVERIFIED evidence
+# gigachat-pro  — продвинутая: mid-confidence или time=MEM
+# local         — экономичная/быстрая: high-confidence
+LAR1_MODEL_GIGACHAT_FAST=GigaChat
+LAR1_MODEL_GIGACHAT_PRO=GigaChat-Pro
+LAR1_MODEL_LOCAL=GigaChat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 Формат основан на [Keep a Changelog](https://keepachangelog.com/ru/1.0.0/),
 и проект придерживается [Семантического версионирования](https://semver.org/lang/ru/).
 
+## [Unreleased]
+
+### Добавлено
+- **LAR-1 semantic routing**: опциональная семантическая маршрутизация для `POST /v1/chat/completions` по `metadata.lar1` (`confidence`, `evidence`, `time`, `act`, `mind`); прокси классифицирует запрос и подменяет `model` на выбранный GigaChat tier до upstream-вызова без дополнительных LLM-запросов на hot path.
+- **LAR-1 configuration**: добавлены env-переменные `LAR1_ENABLED`, `LAR1_THRESHOLD_LOW|MEDIUM|HIGH`, `LAR1_MODEL_GIGACHAT_PRO|GIGACHAT_FAST|LOCAL`; фича выключена по умолчанию (`LAR1_ENABLED=false`).
+- **LAR-1 classifier**: `UNVERIFIED` / low confidence → `gigachat-fast` (экономичная), `time=MEM` / mid confidence → `gigachat-pro` (продвинутая), high confidence → `local` (экономичная/быстрая); решение логируется как `[LAR-1] confidence=… → route (model=…)`.
+- **LAR-1 tests**: добавлены `tests/test_lar1_router.py` (10 unit-тестов классификатора) и integration-тесты хелпера `_apply_lar1_routing` в `tests/test_router/test_lar1_chat_integration.py`.
+
 ## [0.2.2a1] - 2026-06-26
 
 ### Добавлено

--- a/CHANGELOG_en.md
+++ b/CHANGELOG_en.md
@@ -5,6 +5,14 @@ All notable changes to the gpt2giga project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **LAR-1 semantic routing**: optional routing for `POST /v1/chat/completions` based on `metadata.lar1` (`confidence`, `evidence`, `time`, `act`, `mind`); the proxy classifies the request and overrides `model` with the selected GigaChat tier before the upstream call, with no extra LLM calls on the hot path.
+- **LAR-1 configuration**: env vars `LAR1_ENABLED`, `LAR1_THRESHOLD_LOW|MEDIUM|HIGH`, `LAR1_MODEL_GIGACHAT_PRO|GIGACHAT_FAST|LOCAL`; disabled by default (`LAR1_ENABLED=false`).
+- **LAR-1 classifier**: `UNVERIFIED` / low confidence → `gigachat-fast` (economical), `time=MEM` / mid confidence → `gigachat-pro` (advanced), high confidence → `local` (economical/fast); decisions logged as `[LAR-1] confidence=… → route (model=…)`.
+- **LAR-1 tests**: `tests/test_lar1_router.py` (10 classifier unit tests) and `_apply_lar1_routing` integration tests.
+
 ## [0.2.2a1] - 2026-06-26
 
 ### Added

--- a/gpt2giga/app/lifecycle.py
+++ b/gpt2giga/app/lifecycle.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 
 from gpt2giga.app.settings import load_app_config, setup_app_logger
 from gpt2giga.common.model_concurrency import ModelConcurrencyLimiter
+from gpt2giga.models.lar1 import LAR1Settings
 from gpt2giga.protocol import AttachmentProcessor, RequestTransformer, ResponseProcessor
 from gpt2giga.protocols.gemini import GeminiProtocolAdapter
 from gpt2giga.protocols.openai import OpenAIProtocolAdapter
@@ -39,6 +40,7 @@ async def lifespan(app: FastAPI):
 
     app.state.config = config
     app.state.logger = logger
+    app.state.lar1_settings = LAR1Settings()
     if not hasattr(app.state, "openai_protocol_adapter"):
         app.state.openai_protocol_adapter = OpenAIProtocolAdapter()
     if not hasattr(app.state, "gemini_protocol_adapter"):

--- a/gpt2giga/models/lar1.py
+++ b/gpt2giga/models/lar1.py
@@ -1,0 +1,86 @@
+"""LAR-1 semantic metadata models.
+
+LAR-1 adds machine-readable semantics to agent messages:
+act, time, mind, confidence, evidence.
+"""
+
+from enum import Enum
+
+from pydantic import BaseModel, Field, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class LAR1Act(str, Enum):
+    INF = "INF"
+    OBS = "OBS"
+    RET = "RET"
+    GEN = "GEN"
+
+
+class LAR1Time(str, Enum):
+    NOW = "NOW"
+    MEM = "MEM"
+    CTX = "CTX"
+    PRE = "PRE"
+
+
+class LAR1Mind(str, Enum):
+    REF = "REF"
+    REC = "REC"
+    HYP = "HYP"
+    ACT = "ACT"
+
+
+class LAR1Evidence(str, Enum):
+    SYNTH = "SYNTH"
+    RETRIEVED = "RETRIEVED"
+    UNVERIFIED = "UNVERIFIED"
+    CONFIRMED = "CONFIRMED"
+
+
+class LAR1Metadata(BaseModel):
+    act: LAR1Act = LAR1Act.INF
+    time: LAR1Time = LAR1Time.NOW
+    mind: LAR1Mind = LAR1Mind.REF
+    confidence: float = Field(default=0.5, ge=0.0, le=1.0)
+    evidence: list[LAR1Evidence] = Field(default_factory=list)
+
+
+class LAR1Settings(BaseSettings):
+    """Environment-backed LAR-1 routing configuration."""
+
+    enabled: bool = Field(
+        default=False,
+        description="Enable LAR-1 metadata processing and model selection.",
+    )
+    threshold_low: float = Field(default=0.3, ge=0.0, lt=1.0)
+    threshold_medium: float = Field(default=0.5, ge=0.0, lt=1.0)
+    threshold_high: float = Field(default=0.7, ge=0.0, lt=1.0)
+    model_gigachat_pro: str = Field(
+        default="GigaChat-Pro",
+        description="Продвинутая модель GigaChat: mid-confidence или time=MEM.",
+    )
+    model_gigachat_fast: str = Field(
+        default="GigaChat",
+        description="Экономичная модель GigaChat: low-confidence или UNVERIFIED evidence.",
+    )
+    model_local: str = Field(
+        default="GigaChat",
+        description="Экономичная/быстрая модель GigaChat: high-confidence.",
+    )
+
+    model_config = SettingsConfigDict(env_prefix="LAR1_", case_sensitive=False)
+
+    @model_validator(mode="after")
+    def validate_threshold_order(self) -> "LAR1Settings":
+        if not (self.threshold_low < self.threshold_medium < self.threshold_high):
+            msg = "LAR-1 thresholds must satisfy low < medium < high"
+            raise ValueError(msg)
+        return self
+
+    def thresholds(self) -> dict[str, float]:
+        return {
+            "low": self.threshold_low,
+            "medium": self.threshold_medium,
+            "high": self.threshold_high,
+        }

--- a/gpt2giga/routers/lar1_router.py
+++ b/gpt2giga/routers/lar1_router.py
@@ -1,0 +1,57 @@
+"""LAR-1 request classifier for gpt2giga."""
+
+from typing import Mapping, Optional
+
+from gpt2giga.models.lar1 import LAR1Evidence, LAR1Metadata, LAR1Settings, LAR1Time
+
+DEFAULT_LOW = 0.3
+DEFAULT_MEDIUM = 0.5
+DEFAULT_HIGH = 0.7
+
+DEFAULT_THRESHOLDS: dict[str, float] = {
+    "low": DEFAULT_LOW,
+    "medium": DEFAULT_MEDIUM,
+    "high": DEFAULT_HIGH,
+}
+
+LAR1Route = str
+
+
+def classify_request(
+    lar1: LAR1Metadata,
+    thresholds: Optional[Mapping[str, float]] = None,
+) -> LAR1Route:
+    """Classify request target based on LAR-1 metadata.
+
+    Returns one of: ``gigachat-fast``, ``gigachat-pro``, ``local``.
+
+    - ``gigachat-fast``: low confidence or ``UNVERIFIED`` evidence (economical tier)
+    - ``gigachat-pro``: mid confidence or ``MEM`` time (advanced tier)
+    - ``local``: high confidence (economical / fast tier)
+    """
+    t = dict(DEFAULT_THRESHOLDS)
+    if thresholds:
+        t.update(thresholds)
+
+    if LAR1Evidence.UNVERIFIED in lar1.evidence:
+        return "gigachat-fast"
+
+    if lar1.time == LAR1Time.MEM:
+        return "gigachat-pro"
+
+    confidence = lar1.confidence
+
+    if confidence < t["low"]:
+        return "gigachat-fast"
+    if confidence < t["medium"]:
+        return "gigachat-pro"
+    return "local"
+
+
+def resolve_route_model(route: LAR1Route, settings: LAR1Settings) -> str:
+    """Map an internal LAR-1 route label to a GigaChat model id."""
+    if route == "gigachat-pro":
+        return settings.model_gigachat_pro
+    if route == "gigachat-fast":
+        return settings.model_gigachat_fast
+    return settings.model_local

--- a/gpt2giga/routers/openai/chat_completions.py
+++ b/gpt2giga/routers/openai/chat_completions.py
@@ -29,6 +29,7 @@ from gpt2giga.common.streaming import (
 )
 from gpt2giga.core.context import get_request_context, update_request_context
 from gpt2giga.logger import rquid_context
+from gpt2giga.models.lar1 import LAR1Metadata, LAR1Settings
 from gpt2giga.openapi_specs.openai import chat_completions_openapi_extra
 from gpt2giga.openapi_tags import OPENAPI_TAG_OPENAI_CHAT_COMPLETIONS
 from gpt2giga.protocol.response import adapt_chat_completion_to_chat_shape
@@ -47,6 +48,7 @@ from gpt2giga.protocols.openai import (
     normalized_stream_event_to_openai_sse,
 )
 from gpt2giga.providers.gigachat import GigaChatProviderAdapter
+from gpt2giga.routers.lar1_router import classify_request, resolve_route_model
 from gpt2giga.routers.openai.helpers import populate_giga_functions
 from gpt2giga.sinks.observability.factory import emit_observability_event
 from gpt2giga.sinks.observability.llm import (
@@ -64,6 +66,9 @@ router = APIRouter(tags=[OPENAPI_TAG_OPENAI_CHAT_COMPLETIONS])
 async def chat_completions(request: Request):
     """Create a chat completion."""
     data = await read_request_json(request)
+    data, lar1_decision = await _apply_lar1_routing(data, request.app.state)
+    if lar1_decision is not None:
+        update_request_context(metadata={"lar1_decision": lar1_decision})
     conversation_turn = await stitch_chat_payload(request, data, protocol="openai")
     request_data = deepcopy(data)
     request_options = extract_gigachat_request_options(request, data)
@@ -756,3 +761,48 @@ def _string_or_none(value: Any) -> str | None:
     if value is None:
         return None
     return str(value)
+
+
+async def _apply_lar1_routing(
+    data: dict[str, Any],
+    state: Any,
+) -> tuple[dict[str, Any], str | None]:
+    """Extract LAR-1 metadata, classify, and apply the selected GigaChat model."""
+    lar1_settings = _lar1_settings_from_state(state)
+    if not lar1_settings.enabled:
+        return data, None
+
+    metadata = data.get("metadata", {})
+    if not isinstance(metadata, dict):
+        return data, None
+
+    lar1_raw = metadata.get("lar1")
+    if not lar1_raw:
+        return data, None
+
+    logger = getattr(state, "logger", None)
+    try:
+        lar1 = LAR1Metadata.model_validate(lar1_raw)
+        route = classify_request(lar1, lar1_settings.thresholds())
+        model = resolve_route_model(route, lar1_settings)
+        if logger is not None:
+            logger.info(
+                "[LAR-1] confidence={}, evidence={} → {} (model={})",
+                lar1.confidence,
+                [item.value for item in lar1.evidence],
+                route,
+                model,
+            )
+        data["model"] = model
+        return data, route
+    except Exception as exc:
+        if logger is not None:
+            logger.warning("[LAR-1] Parse error: {}", exc)
+        return data, None
+
+
+def _lar1_settings_from_state(state: Any) -> LAR1Settings:
+    cached = getattr(state, "lar1_settings", None)
+    if isinstance(cached, LAR1Settings):
+        return cached
+    return LAR1Settings()

--- a/tests/test_lar1_router.py
+++ b/tests/test_lar1_router.py
@@ -1,0 +1,55 @@
+"""Tests for LAR-1 routing in gpt2giga."""
+
+from gpt2giga.models.lar1 import LAR1Evidence, LAR1Metadata, LAR1Time
+from gpt2giga.routers.lar1_router import classify_request
+
+
+def test_low_confidence_routes_to_gigachat_fast() -> None:
+    lar1 = LAR1Metadata(confidence=0.2)
+    assert classify_request(lar1) == "gigachat-fast"
+
+
+def test_mid_confidence_routes_to_gigachat_pro() -> None:
+    lar1 = LAR1Metadata(confidence=0.4)
+    assert classify_request(lar1) == "gigachat-pro"
+
+
+def test_high_confidence_routes_to_local() -> None:
+    lar1 = LAR1Metadata(confidence=0.8)
+    assert classify_request(lar1) == "local"
+
+
+def test_unverified_evidence_overrides_confidence() -> None:
+    lar1 = LAR1Metadata(confidence=0.9, evidence=[LAR1Evidence.UNVERIFIED])
+    assert classify_request(lar1) == "gigachat-fast"
+
+
+def test_mem_time_routes_to_gigachat_pro() -> None:
+    lar1 = LAR1Metadata(confidence=0.9, time=LAR1Time.MEM)
+    assert classify_request(lar1) == "gigachat-pro"
+
+
+def test_default_confidence_routes_to_local() -> None:
+    lar1 = LAR1Metadata()
+    assert classify_request(lar1) == "local"
+
+
+def test_custom_thresholds() -> None:
+    lar1 = LAR1Metadata(confidence=0.85)
+    thresholds = {"low": 0.1, "medium": 0.3, "high": 0.9}
+    assert classify_request(lar1, thresholds) == "local"
+
+
+def test_confidence_at_boundary() -> None:
+    lar1 = LAR1Metadata(confidence=0.3)
+    assert classify_request(lar1) == "gigachat-pro"
+
+
+def test_zero_confidence() -> None:
+    lar1 = LAR1Metadata(confidence=0.0)
+    assert classify_request(lar1) == "gigachat-fast"
+
+
+def test_full_confidence() -> None:
+    lar1 = LAR1Metadata(confidence=1.0)
+    assert classify_request(lar1) == "local"

--- a/tests/test_router/test_lar1_chat_integration.py
+++ b/tests/test_router/test_lar1_chat_integration.py
@@ -1,0 +1,76 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from gpt2giga.models.lar1 import LAR1Settings
+from gpt2giga.routers.lar1_router import resolve_route_model
+from gpt2giga.routers.openai.chat_completions import _apply_lar1_routing
+
+
+def test_lar1_settings_rejects_invalid_threshold_order() -> None:
+    with pytest.raises(ValueError, match="low < medium < high"):
+        LAR1Settings(threshold_low=0.6, threshold_medium=0.5, threshold_high=0.7)
+
+
+def test_resolve_route_model_maps_labels() -> None:
+    settings = LAR1Settings(
+        model_gigachat_pro="GigaChat-Pro",
+        model_gigachat_fast="GigaChat",
+        model_local="GigaChat-2-Max",
+    )
+    assert resolve_route_model("gigachat-pro", settings) == "GigaChat-Pro"
+    assert resolve_route_model("gigachat-fast", settings) == "GigaChat"
+    assert resolve_route_model("local", settings) == "GigaChat-2-Max"
+
+
+@pytest.mark.asyncio
+async def test_apply_lar1_routing_disabled_by_default() -> None:
+    data = {
+        "model": "GigaChat",
+        "messages": [],
+        "metadata": {"lar1": {"confidence": 0.2, "evidence": [], "time": "NOW"}},
+    }
+    result, decision = await _apply_lar1_routing(data, MagicMock())
+    assert decision is None
+    assert result["model"] == "GigaChat"
+
+
+@pytest.mark.asyncio
+async def test_apply_lar1_routing_overrides_model_when_enabled() -> None:
+    data = {
+        "model": "GigaChat",
+        "messages": [],
+        "metadata": {"lar1": {"confidence": 0.2, "evidence": [], "time": "NOW"}},
+    }
+    logger = MagicMock()
+    state = MagicMock(
+        logger=logger,
+        lar1_settings=LAR1Settings(enabled=True),
+    )
+
+    result, decision = await _apply_lar1_routing(data, state)
+
+    assert decision == "gigachat-fast"
+    assert result["model"] == "GigaChat"
+    assert "_lar1" not in result
+    logger.info.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_apply_lar1_routing_invalid_metadata_is_non_fatal() -> None:
+    data = {
+        "model": "GigaChat",
+        "messages": [],
+        "metadata": {"lar1": {"confidence": "bad"}},
+    }
+    logger = MagicMock()
+    state = MagicMock(
+        logger=logger,
+        lar1_settings=LAR1Settings(enabled=True),
+    )
+
+    result, decision = await _apply_lar1_routing(data, state)
+
+    assert result["model"] == "GigaChat"
+    assert decision is None
+    logger.warning.assert_called_once()


### PR DESCRIPTION
## Описание

Добавляет опциональную семантическую маршрутизацию **LAR-1** в gpt2giga для `POST /v1/chat/completions`.

Agent-клиент передаёт в `metadata.lar1` машиночитаемые сигналы (`confidence`, `evidence`, `time`, `act`, `mind`). Прокси классифицирует запрос и **подменяет `model`** на выбранный tier GigaChat до upstream-вызова. Без `metadata.lar1` или при `LAR1_ENABLED=false` поведение не меняется.

## Мотивация

Сейчас gpt2giga отправляет каждый chat-запрос в одну модель GigaChat. В agent-сценариях это неоптимально по стоимости и качеству:

- при **низкой** уверенности или `UNVERIFIED` evidence — достаточно **экономичной** модели (`gigachat-fast`);
- при **средней** уверенности или `time=MEM` — **продвинутой** (`gigachat-pro`);
- при **высокой** уверенности — снова **экономичной/быстрой** (`local`).

LAR-1 даёт прокси сигнал о качестве контекста **без дополнительных LLM-вызовов** на hot path.

## Тип изменения

- [ ] Исправление бага
- [x] Новая функциональность
- [ ] Ломающее изменение
- [x] Обновление документации
- [ ] Рефакторинг кода
- [x] Улучшение производительности
- [x] Улучшение покрытия тестами
- [ ] Изменение CI/CD или инструментов

## Что изменено

- `gpt2giga/models/lar1.py` — схема LAR-1 metadata и `LAR1Settings` (`LAR1_*` env)
- `gpt2giga/routers/lar1_router.py` — классификатор и маппинг route → GigaChat model id
- `gpt2giga/routers/openai/chat_completions.py` — извлечение `metadata.lar1`, лог `[LAR-1]`, подмена `model`
- `gpt2giga/app/lifecycle.py` — `app.state.lar1_settings`
- `.env.example`, `CHANGELOG.md`, `CHANGELOG_en.md`
- `tests/test_lar1_router.py` (10 unit-тестов), `tests/test_router/test_lar1_chat_integration.py`

### Правила маршрутизации (default)

| Сигнал | Route | Tier | Default model |
|--------|-------|------|---------------|
| `UNVERIFIED` в evidence | `gigachat-fast` | экономичная | `GigaChat` |
| `confidence` < 0.3 | `gigachat-fast` | экономичная | `GigaChat` |
| `time=MEM` | `gigachat-pro` | продвинутая | `GigaChat-Pro` |
| `confidence` < 0.5 | `gigachat-pro` | продвинутая | `GigaChat-Pro` |
| иначе | `local` | экономичная / быстрая | `GigaChat` |

Настройка: `LAR1_ENABLED`, `LAR1_THRESHOLD_*`, `LAR1_MODEL_*`.

## Тестирование

### Покрытие тестами

- [x] Unit-тесты добавлены/обновлены
- [x] Интеграционные тесты добавлены/обновлены
- [x] Все существующие тесты проходят локально

```bash
uv run pytest tests/test_lar1_router.py tests/test_router/test_lar1_chat_integration.py -v
uv run pytest tests/test_router/ tests/test_api_server/test_api_server.py -q
uv run ruff check .
```

### Ручное тестирование

- [x] curl

<details>
<summary>Тестовые команды</summary>

```bash
# .env
LAR1_ENABLED=true

uv run gpt2giga
```

Низкая уверенность → `gigachat-fast`:

```bash
curl -s http://127.0.0.1:8090/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-4",
    "messages": [{"role": "user", "content": "Привет"}],
    "metadata": {"lar1": {"confidence": 0.2, "evidence": [], "time": "NOW"}}
  }'
```

Высокая уверенность → `local`:

```bash
curl -s http://127.0.0.1:8090/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-4",
    "messages": [{"role": "user", "content": "Привет"}],
    "metadata": {"lar1": {"confidence": 0.9, "evidence": ["CONFIRMED"], "time": "NOW"}}
  }'
```

</details>

## Чеклист

### Качество кода

- [x] Код соответствует style guide проекта
- [x] Self-review выполнен
- [x] `ruff check` без новых предупреждений
- [x] Тесты проходят

### Документация

- [x] `.env.example` и CHANGELOG обновлены
- [x] Docstrings в стиле Google

### Зависимости

- [x] Новые зависимости не добавлены

### Совместимость

- [x] Python 3.10–3.14

### Коммиты

- [x] Conventional commits, один squashed commit

## References

- LAR-1 RFC v0.9: https://github.com/cloudiaspecula/lar1-spec

## Дополнительный контекст

Фича **opt-in** (`LAR1_ENABLED=false` по умолчанию). Out of scope: `responses`, Anthropic `/messages`, отдельная страница в `docs/`.
