### PR TITLE
test: verify repository split boundary contracts

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -23,8 +23,10 @@ harness:
       - any-glob-to-any-file:
           - 'packages/gpt2giga-harness/**'
           - 'tests/harness/**'
-          - 'tests/test_package_isolation.py'
-          - 'tests/test_workspace_split_contract.py'
+          - 'tests/package_isolation_support.py'
+          - 'tests/workspace_split_contract_support.py'
+          - 'tests/test_gigaloom_*.py'
+          - 'tests/test_cross_repository_artifact_smoke.py'
           - 'docs/harness.md'
           - 'docs-site/i18n/**/docusaurus-plugin-content-docs/current/harness.md'
 

--- a/tests/package_isolation_support.py
+++ b/tests/package_isolation_support.py
@@ -1,3 +1,5 @@
+"""Transitional artifact helpers used by future repository-owned suites."""
+
 import ast
 from dataclasses import dataclass
 import hashlib
@@ -86,8 +88,7 @@ def _build_member(package: str, output: Path) -> tuple[Path, Path]:
     return wheel, sdist
 
 
-@pytest.fixture(scope="module")
-def built_artifacts(tmp_path_factory) -> BuiltArtifacts:
+def _build_artifacts(tmp_path_factory) -> BuiltArtifacts:
     root = tmp_path_factory.mktemp("workspace-artifacts")
     direct = root / "direct"
     direct.mkdir()
@@ -99,6 +100,11 @@ def built_artifacts(tmp_path_factory) -> BuiltArtifacts:
         harness_wheel=harness_wheel,
         harness_sdist=harness_sdist,
     )
+
+
+@pytest.fixture(scope="module")
+def built_artifacts(tmp_path_factory) -> BuiltArtifacts:
+    return _build_artifacts(tmp_path_factory)
 
 
 def _install_artifacts(target: Path, *artifacts: Path) -> None:

--- a/tests/test_cross_repository_artifact_smoke.py
+++ b/tests/test_cross_repository_artifact_smoke.py
@@ -1,0 +1,119 @@
+"""Cross-repository artifact smoke owned by krakenalt/gigaloom.
+
+Manual candidate invocation:
+
+GIGALOOM_GATEWAY_CANDIDATE_WHEEL=/absolute/path/gpt2giga.whl
+GIGALOOM_GATEWAY_CANDIDATE_SHA256=<sha256>
+GIGALOOM_GATEWAY_CANDIDATE_VERSION=<exact-version>
+uv run pytest tests/test_cross_repository_artifact_smoke.py -q -n 0
+"""
+
+import hashlib
+import os
+from pathlib import Path
+
+import pytest
+
+from package_isolation_support import (
+    BuiltArtifacts,
+    GATEWAY_VERSION,
+    GPT2GIGA_PRESET_SMOKE,
+    _build_artifacts,
+    _build_member,
+    _install_checksum_bound_artifacts,
+    _run_clean_python,
+)
+
+
+FUTURE_REPOSITORY_OWNER = "krakenalt/gigaloom"
+_CANDIDATE_INPUTS = {
+    "wheel": "GIGALOOM_GATEWAY_CANDIDATE_WHEEL",
+    "sha256": "GIGALOOM_GATEWAY_CANDIDATE_SHA256",
+    "version": "GIGALOOM_GATEWAY_CANDIDATE_VERSION",
+}
+
+
+@pytest.fixture(scope="module")
+def built_artifacts(tmp_path_factory) -> BuiltArtifacts:
+    return _build_artifacts(tmp_path_factory)
+
+
+def _manual_gateway_candidate() -> tuple[Path, str, str]:
+    values = {
+        name: os.environ.get(variable) for name, variable in _CANDIDATE_INPUTS.items()
+    }
+    if not any(values.values()):
+        pytest.skip(
+            "manual gateway candidate not provided; no workspace artifact fallback"
+        )
+    missing = [
+        variable for name, variable in _CANDIDATE_INPUTS.items() if not values[name]
+    ]
+    if missing:
+        pytest.fail(f"incomplete manual gateway candidate inputs: {', '.join(missing)}")
+    wheel = Path(values["wheel"]).expanduser().resolve()
+    if not wheel.is_file() or wheel.suffix != ".whl":
+        pytest.fail("manual gateway candidate must be an existing wheel")
+    if values["version"] != GATEWAY_VERSION:
+        pytest.fail(
+            "manual gateway candidate version does not match the exact optional dependency"
+        )
+    return wheel, values["sha256"], values["version"]
+
+
+@pytest.mark.parametrize("artifact_kind", ["wheel", "sdist"])
+def test_monorepo_artifacts_model_checksum_bound_cross_repository_install(
+    built_artifacts: BuiltArtifacts,
+    tmp_path,
+    artifact_kind: str,
+):
+    gateway_artifact = (
+        built_artifacts.gateway_wheel
+        if artifact_kind == "wheel"
+        else built_artifacts.gateway_sdist
+    )
+    harness_artifact = (
+        built_artifacts.harness_wheel
+        if artifact_kind == "wheel"
+        else built_artifacts.harness_sdist
+    )
+    installed = tmp_path / "installed"
+    _install_checksum_bound_artifacts(
+        installed,
+        {
+            gateway_artifact: hashlib.sha256(gateway_artifact.read_bytes()).hexdigest(),
+            harness_artifact: hashlib.sha256(harness_artifact.read_bytes()).hexdigest(),
+        },
+    )
+    _run_clean_python(installed, GPT2GIGA_PRESET_SMOKE)
+
+
+def test_candidate_artifact_digest_mismatch_fails_before_install(
+    built_artifacts: BuiltArtifacts,
+    tmp_path,
+):
+    installed = tmp_path / "installed"
+    with pytest.raises(ValueError, match="candidate artifact digest changed"):
+        _install_checksum_bound_artifacts(
+            installed,
+            {built_artifacts.gateway_wheel: "0" * 64},
+        )
+    assert not installed.exists()
+
+
+def test_manual_gateway_candidate_never_falls_back_to_workspace_source(tmp_path):
+    gateway_wheel, gateway_sha256, gateway_version = _manual_gateway_candidate()
+    assert gateway_version == GATEWAY_VERSION
+
+    harness_dist = tmp_path / "harness-dist"
+    harness_dist.mkdir()
+    harness_wheel, _ = _build_member("gpt2giga-harness", harness_dist)
+    installed = tmp_path / "installed"
+    _install_checksum_bound_artifacts(
+        installed,
+        {
+            gateway_wheel: gateway_sha256,
+            harness_wheel: hashlib.sha256(harness_wheel.read_bytes()).hexdigest(),
+        },
+    )
+    _run_clean_python(installed, GPT2GIGA_PRESET_SMOKE)

--- a/tests/test_gateway_artifact_isolation.py
+++ b/tests/test_gateway_artifact_isolation.py
@@ -1,0 +1,70 @@
+"""Artifact isolation contracts owned by ai-forever/gpt2giga."""
+
+from pathlib import Path
+import tarfile
+
+import pytest
+
+from package_isolation_support import (
+    BuiltArtifacts,
+    GATEWAY_MEMBER,
+    GATEWAY_SMOKE,
+    GATEWAY_VERSION,
+    _artifact_members,
+    _build_artifacts,
+    _install_artifacts,
+    _run_clean_python,
+)
+
+
+FUTURE_REPOSITORY_OWNER = "ai-forever/gpt2giga"
+
+
+@pytest.fixture(scope="module")
+def built_artifacts(tmp_path_factory) -> BuiltArtifacts:
+    return _build_artifacts(tmp_path_factory)
+
+
+@pytest.mark.parametrize("artifact_kind", ["wheel", "sdist"])
+def test_gateway_artifact_is_isolated(
+    built_artifacts: BuiltArtifacts,
+    tmp_path,
+    artifact_kind: str,
+):
+    artifact = (
+        built_artifacts.gateway_wheel
+        if artifact_kind == "wheel"
+        else built_artifacts.gateway_sdist
+    )
+    installed = tmp_path / "installed"
+    _install_artifacts(installed, artifact)
+    _run_clean_python(installed, GATEWAY_SMOKE)
+
+
+def test_editable_gateway_member_resolves_to_gateway_source():
+    import gpt2giga
+    import importlib.metadata
+
+    assert Path(gpt2giga.__file__).resolve().is_relative_to(GATEWAY_MEMBER / "src")
+    assert importlib.metadata.version("gpt2giga") == GATEWAY_VERSION
+
+
+def test_gateway_sdist_is_self_contained(built_artifacts: BuiltArtifacts):
+    with tarfile.open(built_artifacts.gateway_sdist) as archive:
+        names = archive.getnames()
+    assert any(name.endswith("/pyproject.toml") for name in names)
+    assert any(name.endswith("/README.md") for name in names)
+
+
+@pytest.mark.parametrize("artifact_attribute", ["gateway_wheel", "gateway_sdist"])
+def test_gateway_artifacts_do_not_package_gigaloom(
+    built_artifacts: BuiltArtifacts,
+    artifact_attribute: str,
+):
+    artifact = getattr(built_artifacts, artifact_attribute)
+    violations = [
+        name
+        for name in _artifact_members(artifact)
+        if "gpt2giga_harness" in Path(name).parts
+    ]
+    assert violations == []

--- a/tests/test_gateway_release_contract.py
+++ b/tests/test_gateway_release_contract.py
@@ -1,0 +1,49 @@
+"""Release and CI contracts owned by ai-forever/gpt2giga."""
+
+from pathlib import Path
+
+from package_isolation_support import test_workspace_lock_is_current as _check_lock
+from workspace_split_contract_support import (
+    test_code_workflows_skip_documentation_only_changes as _check_code_workflows,
+    test_production_docker_build_remains_gateway_only as _check_gateway_docker,
+)
+
+
+FUTURE_REPOSITORY_OWNER = "ai-forever/gpt2giga"
+_OWNED_SUITE_FILES = (
+    "test_gateway_artifact_isolation.py",
+    "test_gateway_repository_layout.py",
+    "test_gateway_release_contract.py",
+    "test_gigaloom_artifact_isolation.py",
+    "test_gigaloom_repository_layout.py",
+    "test_gigaloom_release_contract.py",
+    "test_cross_repository_artifact_smoke.py",
+)
+
+
+def test_gateway_code_workflows_ignore_documentation_only_changes():
+    _check_code_workflows()
+
+
+def test_gateway_production_docker_build_excludes_gigaloom():
+    _check_gateway_docker()
+
+
+def test_source_workspace_lock_is_current_before_repository_cutover():
+    _check_lock()
+
+
+def test_split_contract_suites_declare_one_future_repository_owner():
+    tests_root = Path(__file__).resolve().parent
+    for filename in _OWNED_SUITE_FILES:
+        source = (tests_root / filename).read_text(encoding="utf-8")
+        declarations = [
+            line
+            for line in source.splitlines()
+            if line.startswith("FUTURE_REPOSITORY_OWNER = ")
+        ]
+        assert len(declarations) == 1, filename
+        assert any(
+            owner in declarations[0]
+            for owner in ("ai-forever/gpt2giga", "krakenalt/gigaloom")
+        ), filename

--- a/tests/test_gateway_repository_layout.py
+++ b/tests/test_gateway_repository_layout.py
@@ -1,0 +1,12 @@
+"""Repository layout contracts owned by ai-forever/gpt2giga."""
+
+from workspace_split_contract_support import (
+    test_gateway_owned_modules_do_not_import_harness as _check_no_harness_imports,
+)
+
+
+FUTURE_REPOSITORY_OWNER = "ai-forever/gpt2giga"
+
+
+def test_gateway_owned_modules_do_not_import_gigaloom():
+    _check_no_harness_imports()

--- a/tests/test_gigaloom_artifact_isolation.py
+++ b/tests/test_gigaloom_artifact_isolation.py
@@ -1,0 +1,106 @@
+"""Artifact and dependency contracts owned by krakenalt/gigaloom."""
+
+from pathlib import Path
+import tarfile
+
+import pytest
+
+from package_isolation_support import (
+    BuiltArtifacts,
+    HARNESS_BASE_SMOKE,
+    HARNESS_MEMBER,
+    HARNESS_VERSION,
+    _artifact_members,
+    _build_artifacts,
+    _install_artifacts,
+    _run_clean_python,
+    test_all_late_bound_gateway_imports_are_characterized as _check_late_imports,
+    test_harness_gateway_imports_stay_within_the_reviewed_boundary as _check_gateway_boundary,
+    test_harness_imports_only_declared_distributions as _check_declared_dependencies,
+    test_installed_third_party_plugin_is_discovered as _check_third_party_plugin,
+    test_neutral_third_party_wheel_registers_without_core_edits as _check_neutral_plugin,
+    test_optional_and_development_dependencies_stay_with_their_owner as _check_optional_dependencies,
+)
+
+
+FUTURE_REPOSITORY_OWNER = "krakenalt/gigaloom"
+
+
+@pytest.fixture(scope="module")
+def built_artifacts(tmp_path_factory) -> BuiltArtifacts:
+    return _build_artifacts(tmp_path_factory)
+
+
+@pytest.mark.parametrize("artifact_kind", ["wheel", "sdist"])
+def test_gigaloom_base_artifact_runs_without_gateway(
+    built_artifacts: BuiltArtifacts,
+    tmp_path,
+    artifact_kind: str,
+):
+    artifact = (
+        built_artifacts.harness_wheel
+        if artifact_kind == "wheel"
+        else built_artifacts.harness_sdist
+    )
+    installed = tmp_path / "installed"
+    _install_artifacts(installed, artifact)
+    _run_clean_python(installed, HARNESS_BASE_SMOKE)
+
+
+def test_editable_gigaloom_member_resolves_to_gigaloom_source():
+    import gpt2giga_harness
+    import importlib.metadata
+
+    assert (
+        Path(gpt2giga_harness.__file__).resolve().is_relative_to(HARNESS_MEMBER / "src")
+    )
+    assert importlib.metadata.version("gpt2giga-harness") == HARNESS_VERSION
+
+
+def test_gigaloom_imports_only_declared_distributions():
+    _check_declared_dependencies()
+
+
+def test_gigaloom_optional_dependencies_stay_with_their_owner():
+    _check_optional_dependencies()
+
+
+def test_gigaloom_gateway_imports_stay_within_reviewed_boundaries():
+    _check_gateway_boundary()
+
+
+def test_all_late_bound_gateway_imports_are_characterized():
+    _check_late_imports()
+
+
+def test_neutral_third_party_wheel_registers_without_core_edits(
+    built_artifacts: BuiltArtifacts,
+    tmp_path,
+):
+    _check_neutral_plugin(built_artifacts, tmp_path)
+
+
+def test_installed_third_party_plugin_is_discovered(
+    built_artifacts: BuiltArtifacts,
+    tmp_path,
+):
+    _check_third_party_plugin(built_artifacts, tmp_path)
+
+
+def test_gigaloom_sdist_is_self_contained(built_artifacts: BuiltArtifacts):
+    with tarfile.open(built_artifacts.harness_sdist) as archive:
+        names = archive.getnames()
+    assert any(name.endswith("/pyproject.toml") for name in names)
+    assert any(name.endswith("/README.md") for name in names)
+
+
+@pytest.mark.parametrize("artifact_attribute", ["harness_wheel", "harness_sdist"])
+def test_gigaloom_artifacts_do_not_package_gateway(
+    built_artifacts: BuiltArtifacts,
+    artifact_attribute: str,
+):
+    artifact = getattr(built_artifacts, artifact_attribute)
+    violations = [
+        name for name in _artifact_members(artifact) if "gpt2giga" in Path(name).parts
+    ]
+    assert violations == []

--- a/tests/test_gigaloom_release_contract.py
+++ b/tests/test_gigaloom_release_contract.py
@@ -1,0 +1,27 @@
+"""Release, documentation, and CI contracts owned by krakenalt/gigaloom."""
+
+from workspace_split_contract_support import (
+    test_ci_builds_and_smokes_both_workspace_artifacts_when_present as _check_artifact_ci,
+    test_pr_labeler_tracks_harness_owned_paths as _check_labeler,
+    test_release_workflow_routes_and_publishes_both_workspace_members as _check_release_workflow,
+    test_split_install_and_namespace_migration_are_documented as _check_migration_docs,
+)
+
+
+FUTURE_REPOSITORY_OWNER = "krakenalt/gigaloom"
+
+
+def test_gigaloom_artifact_ci_builds_and_smokes_distribution():
+    _check_artifact_ci()
+
+
+def test_gigaloom_paths_have_release_label_ownership():
+    _check_labeler()
+
+
+def test_gigaloom_release_workflow_routes_only_owned_distribution():
+    _check_release_workflow()
+
+
+def test_gigaloom_install_and_namespace_migration_are_documented():
+    _check_migration_docs()

--- a/tests/test_gigaloom_repository_layout.py
+++ b/tests/test_gigaloom_repository_layout.py
@@ -1,0 +1,17 @@
+"""Repository layout contracts owned by krakenalt/gigaloom."""
+
+from workspace_split_contract_support import (
+    test_pre_split_relocation_sources_are_present as _check_relocation_sources,
+    test_workspace_member_metadata_and_source_ownership_when_present as _check_workspace_ownership,
+)
+
+
+FUTURE_REPOSITORY_OWNER = "krakenalt/gigaloom"
+
+
+def test_relocation_sources_remain_owned_during_cutover():
+    _check_relocation_sources()
+
+
+def test_gigaloom_workspace_metadata_and_sources_have_one_owner():
+    _check_workspace_ownership()

--- a/tests/test_package_isolation.py
+++ b/tests/test_package_isolation.py
@@ -1,5 +1,6 @@
 import ast
 from dataclasses import dataclass
+import hashlib
 import importlib.metadata
 import json
 import os
@@ -7,6 +8,7 @@ from pathlib import Path
 import subprocess
 import sys
 import tarfile
+import zipfile
 
 import pytest
 
@@ -110,6 +112,19 @@ def _install_artifacts(target: Path, *artifacts: Path) -> None:
         *(str(artifact) for artifact in artifacts),
         cwd=target.parent,
     )
+
+
+def _install_checksum_bound_artifacts(
+    target: Path,
+    artifacts: dict[Path, str],
+) -> None:
+    for artifact, expected_sha256 in artifacts.items():
+        if len(expected_sha256) != 64:
+            raise ValueError(f"invalid SHA-256 for candidate artifact: {artifact.name}")
+        actual_sha256 = hashlib.sha256(artifact.read_bytes()).hexdigest()
+        if actual_sha256 != expected_sha256:
+            raise ValueError(f"candidate artifact digest changed: {artifact.name}")
+    _install_artifacts(target, *artifacts)
 
 
 def _run_clean_python(target: Path, source: str) -> None:
@@ -484,8 +499,25 @@ def test_gpt2giga_preset_artifacts_restore_gateway_runtime(
         else built_artifacts.harness_sdist
     )
     installed = tmp_path / "installed"
-    _install_artifacts(installed, gateway_artifact, harness_artifact)
+    candidate_artifacts = {
+        gateway_artifact: hashlib.sha256(gateway_artifact.read_bytes()).hexdigest(),
+        harness_artifact: hashlib.sha256(harness_artifact.read_bytes()).hexdigest(),
+    }
+    _install_checksum_bound_artifacts(installed, candidate_artifacts)
     _run_clean_python(installed, GPT2GIGA_PRESET_SMOKE)
+
+
+def test_candidate_artifact_digest_mismatch_fails_before_install(
+    built_artifacts: BuiltArtifacts,
+    tmp_path,
+):
+    installed = tmp_path / "installed"
+    with pytest.raises(ValueError, match="candidate artifact digest changed"):
+        _install_checksum_bound_artifacts(
+            installed,
+            {built_artifacts.gateway_wheel: "0" * 64},
+        )
+    assert not installed.exists()
 
 
 def test_neutral_third_party_wheel_registers_without_core_edits(
@@ -612,6 +644,44 @@ def test_harness_gateway_imports_stay_within_the_reviewed_boundary():
     assert "from gpt2giga import run; run()" in proxy_source
 
 
+def test_all_late_bound_gateway_imports_are_characterized():
+    late_bound_imports: set[tuple[str, str]] = set()
+    for path in HARNESS_SOURCE.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        relative_path = path.relative_to(HARNESS_SOURCE).as_posix()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not node.args:
+                continue
+            function_name = (
+                node.func.id
+                if isinstance(node.func, ast.Name)
+                else node.func.attr
+                if isinstance(node.func, ast.Attribute)
+                else None
+            )
+            if function_name == "import_module":
+                module = node.args[0]
+                if (
+                    isinstance(module, ast.Constant)
+                    and isinstance(module.value, str)
+                    and module.value.startswith("gpt2giga.")
+                ):
+                    late_bound_imports.add((relative_path, module.value))
+            for argument in ast.walk(node.args[0]):
+                if (
+                    isinstance(argument, ast.Constant)
+                    and isinstance(argument.value, str)
+                    and "from gpt2giga import" in argument.value
+                ):
+                    late_bound_imports.add((relative_path, argument.value))
+
+    assert late_bound_imports == {
+        ("gpt2giga_preset.py", "gpt2giga.cli"),
+        ("openai_upstream.py", "gpt2giga.providers.openai_compatible"),
+        ("proxy.py", "from gpt2giga import run; run()"),
+    }
+
+
 def _write_minimal_plugin(source_root: Path) -> None:
     package = source_root / "src/example_harness_plugin"
     package.mkdir(parents=True)
@@ -709,3 +779,34 @@ def test_sdists_are_self_contained(built_artifacts: BuiltArtifacts):
             names = archive.getnames()
         assert any(name.endswith("/pyproject.toml") for name in names)
         assert any(name.endswith("/README.md") for name in names)
+
+
+def _artifact_members(path: Path) -> tuple[str, ...]:
+    if path.suffix == ".whl":
+        with zipfile.ZipFile(path) as archive:
+            return tuple(archive.namelist())
+    with tarfile.open(path) as archive:
+        return tuple(archive.getnames())
+
+
+@pytest.mark.parametrize(
+    ("artifact_attribute", "forbidden_package"),
+    [
+        ("gateway_wheel", "gpt2giga_harness"),
+        ("gateway_sdist", "gpt2giga_harness"),
+        ("harness_wheel", "gpt2giga"),
+        ("harness_sdist", "gpt2giga"),
+    ],
+)
+def test_artifacts_do_not_package_the_other_distribution(
+    built_artifacts: BuiltArtifacts,
+    artifact_attribute: str,
+    forbidden_package: str,
+):
+    artifact = getattr(built_artifacts, artifact_attribute)
+    violations = [
+        name
+        for name in _artifact_members(artifact)
+        if forbidden_package in Path(name).parts
+    ]
+    assert violations == []

--- a/tests/workspace_split_contract_support.py
+++ b/tests/workspace_split_contract_support.py
@@ -1,3 +1,5 @@
+"""Transitional source-workspace assertions grouped by future owner."""
+
 import ast
 from pathlib import Path
 import subprocess
@@ -287,6 +289,8 @@ def test_pr_labeler_tracks_harness_owned_paths():
     assert "harness:" in labeler
     assert "- 'packages/gpt2giga-harness/**'" in labeler
     assert "- 'tests/harness/**'" in labeler
+    assert "- 'tests/test_gigaloom_*.py'" in labeler
+    assert "- 'tests/test_cross_repository_artifact_smoke.py'" in labeler
     assert "- 'docs/harness.md'" in labeler
 
 


### PR DESCRIPTION
## What changed

- freeze gateway and GigaLoom artifact-isolation boundaries before repository extraction
- split monorepo isolation and layout tests into gateway-owned, GigaLoom-owned, and explicit cross-repository suites
- require checksum- and version-bound gateway candidate wheels for manual compatibility smoke tests, with no editable or workspace fallback
- align the PR labeler with the new GigaLoom-owned test paths

## Why

The repository split must be reproducible from public source history. These characterization contracts make ownership and cross-repository compatibility executable before history extraction begins.

## Impact

There is no product behavior, package name, namespace, CLI, state-directory, release, or target-repository change. This PR adds and reorganizes test contracts only.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- focused split suites: 32 passed, 1 intentional missing-candidate skip
- positive checksum-bound candidate-wheel smoke: 1 passed
- full suite: 2914 passed, 3 skipped; coverage 85.11%
- `uv build --package gpt2giga --no-sources`
- `uv build --package gpt2giga-harness --no-sources`
- `git diff --check`
